### PR TITLE
Fix nb_NO translation integration

### DIFF
--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -25,11 +25,8 @@
 
     <!-- About -->
     <string name="app_name">Diskret oppstarter</string>
-    <string name="author" translatable="false">Vincent Falzon</string>
     <string name="licence_name">GPLv3+</string>
-    <string name="license_link" translatable="false">https://gnu.org/licenses/gpl-3.0.txt</string>
     <string name="website_description">Foreslå forbedringer og innrapporter feil på</string>
-    <string name="website_link" translatable="false">https://vincent-falzon.com</string>
     <string name="translation_credit">Norsk oversettelse ved Allan Nordhøy</string>
 
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Applications list -->
+    <!-- List of Applications -->
     <string name="info_applications_list_refreshed">Programliste gjenoppfrisket</string>
     <string name="button_refresh_list">Gjenoppfrisk programlisten</string>
     <string name="error_application_not_found">Fant ikke «%1$s»</string>
@@ -13,8 +13,8 @@
     <string name="hint_modify_order_of_favorites">Endre rekkefølgen nedenfor (og rull ved bruk av sidene).</string>
 
     <!-- Dialogs buttons -->
-	<string name="button_apply">Bruk</string>
-	<string name="button_cancel">Avbryt</string>
+    <string name="button_apply">Bruk</string>
+    <string name="button_cancel">Avbryt</string>
 
     <!-- Long click options -->
     <string name="long_click_title">Hva ønsker du å gjøre?</string>
@@ -25,8 +25,11 @@
 
     <!-- About -->
     <string name="app_name">Diskret oppstarter</string>
+    <string name="author" translatable="false">Vincent Falzon</string>
     <string name="licence_name">GPLv3+</string>
+    <string name="license_link" translatable="false">https://gnu.org/licenses/gpl-3.0.txt</string>
     <string name="website_description">Foreslå forbedringer og innrapporter feil på</string>
+    <string name="website_link" translatable="false">https://vincent-falzon.com</string>
     <string name="translation_credit">Norsk oversettelse ved Allan Nordhøy</string>
 
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -27,6 +27,6 @@
     <string name="app_name">Diskret oppstarter</string>
     <string name="licence_name">GPLv3+</string>
     <string name="website_description">Foreslå forbedringer og innrapporter feil på</string>
-    <string name="translation_credit">Norsk oversettelse ved Allan Nordhøy</string>
+    <string name="translation_credit">Norsk oversettelse ved Allan Nordhøy, epost@anotheragency.no</string>
 
 </resources>

--- a/app/src/main/res/values-nb-rNO/strings_help.xml
+++ b/app/src/main/res/values-nb-rNO/strings_help.xml
@@ -16,7 +16,7 @@
     <string name="help_notification_title">Merknad</string>
     <string name="help_notification_text">
         Viser et oppsprett av favoritter over andre programmer når du forlater hjemmeskjermen.
-        </string>
+    </string>
     <string name="help_list_update_title">Listegjenoppfriskning</string>
     <string name="help_list_update_text">
         En oppsprettsmelding vises ved gjenoppfrisking av programlisten og ikoner,

--- a/app/src/main/res/values-nb-rNO/strings_settings.xml
+++ b/app/src/main/res/values-nb-rNO/strings_settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Settings interface -->
+    <!-- Setting titles -->
     <string name="title_settings_and_help">Innstillinger og hjelp</string>
     <string name="title_section_customization">Tilpasning</string>
     <string name="title_section_help_and_general_info">Hjelp og generell info</string>

--- a/app/src/main/res/values-nb-rNO/strings_settings.xml
+++ b/app/src/main/res/values-nb-rNO/strings_settings.xml
@@ -93,8 +93,8 @@
     <string name="set_immersive_mode_help">Skjul systembjelker (lang-trykk på hjemmeskjermen for å påtvinge)</string>
     <string name="set_reverse_interface">Omvendt grensesnitt</string>
     <string name="set_reverse_interface_help">Programmer ovenfor, og favorittpanel på bunnen</string>
-    <string name="set_disable_app_drawer">No app drawer</string>
-    <string name="error_disable_app_drawer_not_safe">Reinstating the app drawer to keep menu access.</string>
+    <string name="set_disable_app_drawer">Ingen programkurv</string>
+    <string name="error_disable_app_drawer_not_safe">Legger inn programkurven igjen for å beholde menytilgang.</string>
     <string name="error_appfilter_not_found">Fant ikke appfilter.xml.filen i angitt programpakke. (%1$s)</string>
 
     <!-- Export and import -->


### PR DESCRIPTION
Don't think this does anything, but I also can't figure out why the build breaks…

There is an extra `/` in https://github.com/falzonv/discreet-launcher/pull/77/files#diff-d0c61e533993db7b1d779138cff623d901b1893361374df34f72cc7d92c7a246R33
but that looks to have been removed when merging.