### PR TITLE
Fuzzy search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,4 +48,5 @@ dependencies
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.preference:preference:1.1.1'
+    implementation 'it.andreuzzi:CompareString2:1.0.9'
 }

--- a/app/src/main/java/com/vincent_falzon/discreetlauncher/SearchAdapter.java
+++ b/app/src/main/java/com/vincent_falzon/discreetlauncher/SearchAdapter.java
@@ -28,7 +28,10 @@ import android.view.View ;
 import android.widget.Filter ;
 import android.widget.Filterable ;
 import com.vincent_falzon.discreetlauncher.core.Application ;
-import java.text.Collator ;
+import it.andreuzzi.comparestring2.AlgMap;
+import it.andreuzzi.comparestring2.Utils;
+import it.andreuzzi.comparestring2.algs.interfaces.Algorithm;
+
 import java.util.ArrayList ;
 
 /**
@@ -38,8 +41,6 @@ public class SearchAdapter extends RecyclerAdapter implements Filterable
 {
 	// Attributes
 	private final ArrayList<Application> initialApplicationsList ;
-	private final Collator collator ;
-
 
 	/**
 	 * Constructor to fill a RecyclerView with the applications list.
@@ -51,8 +52,6 @@ public class SearchAdapter extends RecyclerAdapter implements Filterable
 
 		// Initializations
 		initialApplicationsList = applicationsList ;
-		collator = Collator.getInstance() ;
-		collator.setStrength(Collator.PRIMARY) ;
 	}
 
 
@@ -77,11 +76,15 @@ public class SearchAdapter extends RecyclerAdapter implements Filterable
 					{
 						// Filter results based on the search pattern ignoring case and accents
 						applicationsList = new ArrayList<>() ;
-						int search_length = search.length() ;
+
+						final Algorithm algorithm = AlgMap.NormSimAlg.JAROWRINKLER.buildAlg();
+
 						for(Application application : initialApplicationsList)
 						{
 							String app_name = application.getDisplayName() ;
-							if(collator.equals(app_name.substring(0, Math.min(search_length, app_name.length())), search))
+
+							float compare = Utils.compare(app_name, search, algorithm, AlgMap.NormSimAlg.JAROWRINKLER);
+							if(compare > 0.5)
 								applicationsList.add(application) ;
 						}
 					}

--- a/app/src/main/java/com/vincent_falzon/discreetlauncher/SearchAdapter.java
+++ b/app/src/main/java/com/vincent_falzon/discreetlauncher/SearchAdapter.java
@@ -29,10 +29,11 @@ import android.widget.Filter ;
 import android.widget.Filterable ;
 import com.vincent_falzon.discreetlauncher.core.Application ;
 import it.andreuzzi.comparestring2.AlgMap;
-import it.andreuzzi.comparestring2.Utils;
+import it.andreuzzi.comparestring2.CompareObjects;
 import it.andreuzzi.comparestring2.algs.interfaces.Algorithm;
 
 import java.util.ArrayList ;
+import java.util.Arrays;
 
 /**
  * Fill a RecyclerView with a list of applications filtered with a search result.
@@ -74,19 +75,22 @@ public class SearchAdapter extends RecyclerAdapter implements Filterable
 				if(search.isEmpty()) applicationsList = initialApplicationsList ;
 					else
 					{
-						// Filter results based on the search pattern ignoring case and accents
-						applicationsList = new ArrayList<>() ;
+						final AlgMap.Alg algorithm = AlgMap.NormSimAlg.JAROWRINKLER ;
+						final Algorithm algorithmInstance = AlgMap.NormSimAlg.JAROWRINKLER.buildAlg() ;
+						final String[] splitters = {" "} ;
 
-						final Algorithm algorithm = AlgMap.NormSimAlg.JAROWRINKLER.buildAlg();
+						Application[] matches = CompareObjects.topMatchesWithDeadline(
+								Application.class,
+								search,
+								initialApplicationsList.size(),
+								initialApplicationsList,
+								4,
+								0.45f,
+								splitters,
+								algorithmInstance,
+								algorithm) ;
 
-						for(Application application : initialApplicationsList)
-						{
-							String app_name = application.getDisplayName() ;
-
-							float compare = Utils.compare(app_name, search, algorithm, AlgMap.NormSimAlg.JAROWRINKLER);
-							if(compare > 0.5)
-								applicationsList.add(application) ;
-						}
+						applicationsList = new ArrayList<>(Arrays.asList(matches)) ;
 					}
 
 				// Prepare the filter results

--- a/app/src/main/java/com/vincent_falzon/discreetlauncher/core/Application.java
+++ b/app/src/main/java/com/vincent_falzon/discreetlauncher/core/Application.java
@@ -32,11 +32,12 @@ import android.graphics.drawable.Drawable ;
 import android.net.Uri ;
 import android.os.UserHandle ;
 import android.view.View ;
+import it.andreuzzi.comparestring2.StringableObject;
 
 /**
  * Represent an Android application (userHandle is used to identify work profile apps).
  */
-public class Application
+public class Application implements StringableObject
 {
 	// Attributes
 	String display_name ;
@@ -197,5 +198,15 @@ public class Application
 		settingsIntent.setData(Uri.parse("package:" + apk)) ;
 		settingsIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK) ;
 		context.startActivity(settingsIntent) ;
+	}
+
+	@Override
+	public String getLowercaseString() {
+		return getDisplayName().toLowerCase() ;
+	}
+
+	@Override
+	public String getString() {
+		return getDisplayName() ;
 	}
 }


### PR DESCRIPTION
I was previously using the [T-UI](https://github.com/fAndreuzzi/TUI-ConsoleLauncher) launcher and I really liked the feature it has where searching for applications is done using a very fuzzy search that mostly finds what I want even when I don't quite remember the name of the application or when I make a bunch of typos.

I wanted to try if I could adopt that functionality into your excellent Discreet Launcher.

Examples of apps where this really helps:
* Apps with a stupid prefix like "MyMail". I want to find it by typing "mail"
* Apps with a common grouping prefix. I use a couple of apps that come from the same publisher and they all have "S-" as a prefix. I want to find them without having to type an S and a dash.

I understand that keeping the binary size quite small is one of your aims in this project, so including the https://github.com/fAndreuzzi/CompareString2 library and it's dependencies may not be what you want. If that is the case, then I hope this PR functions as a source of inspiration and you will come up with an even better way to add something like this to your launcher.

### Technical details

* Actual code is mostly "stolen" from here: https://github.com/fAndreuzzi/TUI-ConsoleLauncher/blob/1f7c2c5b943311c44241c795452cd63b5233e921/app/src/main/java/ohi/andre/consolelauncher/managers/suggestions/SuggestionsManager.java#L1092
* I tried to dig up the default algorithm and parameters used by T-UI:
  * `AlgMap.NormSimAlg.JAROWRINKLER`
  * `0.45` as the min/max rank required
  * Using space as a splitter character
* I limit it to 4 matches since 4 icons fit nicely in a row and when I'm searching for an app I really only want to find the one app.

All of the hard work with the string comparison algorithms comes from https://github.com/tdebatty/java-string-similarity (https://github.com/fAndreuzzi/CompareString2 is just a wrapper)