### PR TITLE
Change the url of the play store badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Enjoy a clean home screen while accessing everything in an instant!
 
 [![](https://img.shields.io/github/v/release/falzonv/discreet-launcher?label=Latest%20release&style=plastic)](https://github.com/falzonv/discreet-launcher/releases)
 [![](https://img.shields.io/f-droid/v/com.vincent_falzon.discreetlauncher?include_prereleases&label=F-Droid%20release&style=plastic)](https://f-droid.org/en/packages/com.vincent_falzon.discreetlauncher)
-[![](https://img.shields.io/endpoint?style=plastic&color=blue&label=Google%20Play%20release&url=https://playshields.herokuapp.com/play?i=com.vincent_falzon.discreetlauncher&m=$version)](https://play.google.com/store/apps/details?id=com.vincent_falzon.discreetlauncher)  
+[![](https://img.shields.io/endpoint?style=plastic&color=blue&label=Google%20Play%20release&url=https://play.cuzi.workers.dev/play?i=com.vincent_falzon.discreetlauncher&m=$version)](https://play.google.com/store/apps/details?id=com.vincent_falzon.discreetlauncher)  
 Please note that the F-Droid build and publishing process is automatic and usually take 4 to 8 days to complete.
 You may see a gap between the latest release and what is really available on F-Droid.  
 *(Le processus de compilation et de publication par F-Droid est automatique et prend généralement 4 à 8 jours.


### PR DESCRIPTION
Changes the domain of the play store badge

The old service is running on a free heroku account, but [Heroku will stop offering free accounts](https://help.heroku.com/RSBRUH58/removal-of-heroku-free-product-plans-faq) at the end of November.
The [new service](https://github.com/cvzi/play) is running on a free Cloudflare worker.