### PR TITLE
String settings reworked

### DIFF
--- a/app/src/main/res/values-nb-rNO/strings_settings.xml
+++ b/app/src/main/res/values-nb-rNO/strings_settings.xml
@@ -165,7 +165,7 @@
     <string name="set_immersive_mode">Oppslukende modus</string>
     <string name="set_immersive_mode_help">Skjul systembjelker (lang-trykk på hjemmeskjermen for å påtvinge)</string>
     <string name="set_interactive_clock">Interaktiv klokke</string>
-    <string name="set_interactive_clock_help">Klikk på datoen for å åpne forvalgt kalenderprogram, og klokken for å åpne valgt klokkeprogram.</string>
+    <string name="set_interactive_clock_help">Klikk på datoen for å åpne forvalgt kalenderprogram, og klokkn for å åpne valgt klokkeprogram.</string>
     <string name="set_clock_app">Klokkeprogram</string>
     <string name="set_no_clock_app">Ingen</string>
     <string name="set_hide_menu_button">Ingen menyknapp</string>

--- a/app/src/main/res/values-nb-rNO/strings_settings.xml
+++ b/app/src/main/res/values-nb-rNO/strings_settings.xml
@@ -165,7 +165,7 @@
     <string name="set_immersive_mode">Oppslukende modus</string>
     <string name="set_immersive_mode_help">Skjul systembjelker (lang-trykk på hjemmeskjermen for å påtvinge)</string>
     <string name="set_interactive_clock">Interaktiv klokke</string>
-    <string name="set_interactive_clock_help">Klikk på datoen for å åpne forvalgt kalenderprogram, og klokkn for å åpne valgt klokkeprogram.</string>
+    <string name="set_interactive_clock_help">Klikk på datoen for å åpne forvalgt kalenderprogram, og klokken for å åpne valgt klokkeprogram.</string>
     <string name="set_clock_app">Klokkeprogram</string>
     <string name="set_no_clock_app">Ingen</string>
     <string name="set_hide_menu_button">Ingen menyknapp</string>

--- a/app/src/main/res/values/strings_settings.xml
+++ b/app/src/main/res/values/strings_settings.xml
@@ -6,9 +6,9 @@
     <string name="button_sort_az">Sort A-Z</string>
     <string name="hint_no_favorites_yet">Add your favorite apps here\nby clicking the menu button.</string>
     <string name="hint_modify_order_of_favorites">Modify the order of favorites below.</string>
-    <string name="hint_sort_favorites_az">The current order of favorites will be replaced by alphabetical order.</string>
-    <string name="favorite_move_before">Move before \"%1$s\"</string>
-    <string name="favorite_move_after">Move after \"%1$s\"</string>
+    <string name="hint_sort_favorites_az">Sorts favorites alphabetically.</string>
+    <string name="favorite_move_before">Place before \"%1$s\"</string>
+    <string name="favorite_move_after">Place after \"%1$s\"</string>
 
     <!-- Folders -->
     <string name="button_new_folder">Add</string>
@@ -20,7 +20,7 @@
     </string>
     <string name="hint_new_folder">New folder</string>
     <string name="hint_rename_folder">Rename folder</string>
-    <string name="hint_remove_folder">If a folder is removed, its content will be put back in the main app list.</string>
+    <string name="hint_remove_folder">Removing a folder puts its content back into the main app list.</string>
     <string name="error_folder_empty_name">Pick a name first</string>
     <string name="error_folder_already_exists">Pick a name that doesn\'t exist already</string>
     <string name="error_folder_rename">Could not rename the folder</string>
@@ -34,8 +34,8 @@
     <string name="export_import_header_icons">Saved icons</string>
     <string name="export_import_warning_file_edit">Editing this file may cause problems</string>
     <string name="export_import_warning_shortcuts">
-        (On Android 8 (Oreo) and beyond, imported shortcuts may not work
-        because they are managed by the system and are not supposed to be exported)
+        (On Android 8 (Oreo) and beyond, imported shortcuts may not work,
+        as they are managed by the system and not supposed to be exported.)
     </string>
     <string name="export_completed">Export completed</string>
     <string name="error_export">Could not create export file</string>
@@ -52,13 +52,14 @@
     <!-- ========== Appearance settings menu ========== -->
 
     <!-- Sections titles -->
-    <string name="appearance_settings_title_theme_and_colors">Theme and colors</string>
+    <string name="appearance_settings_title_theme_and_colors">Interface</string>
     <string name="appearance_settings_title_clock">Clock</string>
-    <string name="appearance_settings_title_icon_packs">Icon packs</string>
+    <string name="appearance_settings_title_icon_packs">Icons</string>
 
     <!-- Color picker -->
     <string name="color_picker_base">Base:</string>
     <string name="color_picker_reset">Reset</string>
+        <!-- (This is a label for a shown preview, not a verb.) -->
     <string name="color_picker_preview">Preview</string>
     <string name="error_invalid_color_format">Invalid hexadecimal color</string>
 
@@ -71,7 +72,7 @@
     </string-array>
 
     <!-- Clock format -->
-    <string name="set_clock_format">Clock format</string>
+    <string name="set_clock_format">Format</string>
     <string-array name="set_clock_format_entries">
         <item>None (hide)</item>
         <item>24 hours</item>
@@ -83,7 +84,7 @@
     </string-array>
 
     <!-- Clock position (double spaces are intentional) -->
-    <string name="set_clock_position">Clock position</string>
+    <string name="set_clock_position">Position</string>
     <string-array name="set_clock_position_entries">
         <item>Top</item>
         <item>"Top  -  Left"</item>
@@ -97,7 +98,7 @@
     </string-array>
 
     <!-- Clock size -->
-    <string name="set_clock_size">Clock size</string>
+    <string name="set_clock_size">Size</string>
     <string-array name="set_clock_size_entries">
         <item>Small</item>
         <item>Medium</item>
@@ -109,7 +110,7 @@
     <string name="set_transparent_status_bar_help">When favorites are closed</string>
     <string name="set_dark_status_bar_icons">Dark status bar icons</string>
     <string name="set_dark_status_bar_icons_help">Not working on Android 5 (Lollipop)</string>
-    <string name="set_icon_size">Icon size</string>
+    <string name="set_icon_size">Size</string>
     <string name="set_hide_app_names">No app names</string>
     <string name="set_hide_folder_names">No folder names</string>
     <string name="set_remove_padding">No padding when app names are hidden</string>
@@ -117,13 +118,13 @@
     <string name="set_text_color_favorites">Favorites text</string>
     <string name="set_background_color_drawer">App drawer background</string>
     <string name="set_text_color_drawer">App drawer text</string>
-    <string name="set_clock_color">Clock color</string>
+    <string name="set_clock_color">Color</string>
     <string name="set_clock_shadow_color">Text shadow color</string>
     <string name="set_icon_pack_primary">Primary</string>
     <string name="set_icon_pack_secondary">Secondary</string>
     <string name="set_icon_pack_none">None (use default icons)</string>
-    <string name="set_icon_color_filter">Color filter on icons</string>
-    <string name="set_icon_color_filter_help">Only applies to default icons, can be used in addition to icon packs</string>
+    <string name="set_icon_color_filter">Color filter</string>
+    <string name="set_icon_color_filter_help">Only applies to default icons. Can be used in addition to icon packs</string>
 
     <!-- Error messages related to appearance settings -->
     <string name="error_no_icon_pack_installed">Install some from your app store first</string>


### PR DESCRIPTION
All in the interest of making it more "Discreet"

0 It doesn't make sense to me that many of the things in "Use" have UI settings, and the clock options are split between the two categories.

1 I think `<string name="hint_folders_number">Create as many folders as you want to organize your apps.</string>`
can be removed.

2 Also it would be interesting to have arrows instead of the clock placement strings.
↑↓←→
↖ ↗↘↙
(If they all work)

3 and something like ○ ◯ for clock size.

4 The text "Does not work on Android 5 (Lollypop" is only really relevant to people that have Android 5, in which case it might just be grayed out with that message. It doesn't need to be shown to others.

5 I don't know what "transparent status field" does, but that could be the default maybe?

6 There is no setting to remove the darkened background when opening the settings?
<!--
Hello,

Thank you very much for your interest in this project!

For requests other than translations, could you please explain the context and purpose in the description?

I like to improve my code following feedback but have to admit that doing code review is not my cup of tea.
For now I prefer to manage all the code myself as the project is small enough to allow it. This is what personally motivates me in maintaining this project.
Consequently, don't be surprised if pull requests related to code are closed.
Instead, feel free to suggest improvements in the "Issues" tab so we can discuss them together.

Best regards.
-->
### Description



