### PR TITLE
Update translations for next release

### DIFF
--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -186,7 +186,7 @@
     <!-- Notification -->
     <string name="set_notification">Notificação para acessar os favoritos</string>
     <string name="set_notification_help">Usar um ícone transparente</string>
-    <string name="set_notification_warning_disabled">Notifications are disabled by system settings</string>
+    <string name="set_notification_warning_disabled">Notificações estão desabilitadas nas configurações do sistema</string>
     <string name="notification_text">Favoritos</string>
 
     <!-- Forced orientation -->
@@ -205,7 +205,7 @@
     <string name="target_close_favorites">Fechar\nfavoritos</string>
     <string name="target_open_apps">Abrir\naplicativos</string>
     <string name="target_close_apps">Fechar\naplicativos</string>
-    <string name="help_touch_targets">Swipe down to display the menu button, you can enable touch targets in the Operation menu</string><!-- (home screen TTS description for accessibility) -->
+    <string name="help_touch_targets">Deslize para baixo para exibir o botão do menu, você pode desabilitar os alvos de toque nas configurações gerais</string><!-- (home screen TTS description for accessibility) -->
 
     <!-- Other operation settings -->
     <string name="set_as_default_launcher">Selecionar como lançador padrão</string>


### PR DESCRIPTION
Following https://github.com/falzonv/discreet-launcher/issues/80#issuecomment-2266177212

I was a bit unsure about the translation of 'touch targets', I translated it literally (alvo = target = cible), but I now saw that the [Android documentation page](https://support.google.com/accessibility/android/answer/7101858?hl=pt-BR&sjid=1240457181743975572-SA) uses área (area = aire). I don't know if that page is machine translated though, so I'm not 100% sure if I should change it. What do you think?